### PR TITLE
change fromError to to_object and adjust tests

### DIFF
--- a/lib/response/response.js
+++ b/lib/response/response.js
@@ -7,7 +7,7 @@ function Response (data, is_error, type, status_message) {
 	this.data = data || {};
 }
 
-Response.fromError = function(sealious_error){
+Response.to_object = function(sealious_error){
 	return {
 		data: sealious_error.data || {},
 		is_error: true,

--- a/tests/unit-tests/response/response.test.js
+++ b/tests/unit-tests/response/response.test.js
@@ -15,7 +15,7 @@ describe("Sealious.Response", function(){
 	});
 	it("returns a Response object from an error", function() {
 		const error = new Sealious.Errors.BadContext("This is an error", "test_data");
-		const response = Response.fromError(error);
+		const response = Response.to_object(error);
 		assert.strictEqual(response.data, "test_data");
 		assert.strictEqual(response.type, "permission");
 		assert.strictEqual(response.status_message, "This is an error");


### PR DESCRIPTION
What a collosal change - I know. Nevertheless `Sealious.Error` has method `to_object` and I believe `to_object` better describes as method than `fromError`. :)