### PR TITLE
Rewrite version checking

### DIFF
--- a/lib/utils/check-for-updates.js
+++ b/lib/utils/check-for-updates.js
@@ -2,12 +2,13 @@ const request = require("request-promise");
 const Logger = require.main.require("lib/logger/logger.js");
 const Errors = require.main.require("lib/response/error.js");
 
-function CheckVersion(pkg) {
+function check_for_updates(pkg) {
     if (typeof pkg === "object") {
         const pkg_split = pkg.version.split(".");
         const version = pkg_split[0] + "." + pkg_split[1];
         const url = "http://registry.npmjs.org/sealious/" + version;
-        let status = "warning", message;
+        let status = "warning";
+        let message;
 
         return request(url)
             .then(res => JSON.parse(res))
@@ -38,4 +39,4 @@ function CheckVersion(pkg) {
     }
 }
 
-module.exports = CheckVersion;
+module.exports = check_for_updates;

--- a/lib/utils/check-version.js
+++ b/lib/utils/check-version.js
@@ -1,0 +1,41 @@
+const request = require("request-promise");
+const Logger = require.main.require("lib/logger/logger.js");
+const Errors = require.main.require("lib/response/error.js");
+
+function CheckVersion(pkg) {
+    if (typeof pkg === "object") {
+        const pkg_split = pkg.version.split(".");
+        const version = pkg_split[0] + "." + pkg_split[1];
+        const url = "http://registry.npmjs.org/sealious/" + version;
+        let status = "warning", message;
+
+        return request(url)
+            .then(res => JSON.parse(res))
+            .then(function(sealious_npm) {
+                if (sealious_npm.error){
+                    message = `npm registry error when requesting info for version ${version}: ${sealious_npm.error}`;
+                } else if (!sealious_npm.version || sealious_npm === undefined){
+                    message = `unknown npm registry error when requesting info for version ${version}`;
+                } else {
+                    const sealious_npm_array = sealious_npm.version.split(".");
+
+                    if ((sealious_npm.version !== pkg.version) && (parseInt(sealious_npm_array[2]) > parseInt(pkg_split[2]))) {
+                        message = `Sealious@${pkg.version} - update available. Run "npm install sealious@${sealious_npm.version}" to update.`
+                    } else {
+                        status = "info";
+                        message = `Sealious@${pkg.version} is up-to-date`
+                    }
+                }
+                return {status, message};
+            })
+            .catch(function(err) {
+                Logger.warning("No network connection available! Unable to fetch information about Sealious updates.");
+                throw err;
+            });
+    }
+    else {
+        throw new Errors.ValidationError("Wrong arguments was passed!");
+    }
+}
+
+module.exports = CheckVersion;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "fs-extra": "^0.30.0",
     "merge": "^1.2.0",
     "node-uuid": "^1.4.7",
+    "request-promise": "^4.0.2",
     "require-dir": "^0.3.0",
     "resolve": "^1.1.7",
     "sanitize-html": "^1.6.1",

--- a/tests/unit-tests/utils/check-version.test.js
+++ b/tests/unit-tests/utils/check-version.test.js
@@ -1,12 +1,12 @@
-const CheckVersion = require.main.require("lib/utils/check-version.js");
+const check_for_updates = require.main.require("lib/utils/check-for-updates.js");
 const request = require("request-promise");
 const assert = require("assert");
 
-describe("Sealious.CheckVersion", function() {
+describe("Sealious.check_for_updates", function() {
     it("says there are no updates to Sealious", function(done) {
         request("http://registry.npmjs.org/sealious/0.7")
             .then(res => JSON.parse(res))
-            .then(sealious_npm => CheckVersion(sealious_npm))
+            .then(sealious_npm => check_for_updates(sealious_npm))
             .then( ({status, message}) => {
                 assert.strictEqual(status, "info");
                 assert.notStrictEqual(message.indexOf("up-to-date"), -1);
@@ -18,7 +18,7 @@ describe("Sealious.CheckVersion", function() {
     });
     it("says there are updates to Sealious", function(done) {
         const pkg = {version: "0.7.1"};
-        CheckVersion(pkg)
+        check_for_updates(pkg)
             .then( ({status, message}) => {
                 assert.strictEqual(status, "warning");
                 assert.notStrictEqual(message.indexOf("update available"), -1);
@@ -30,7 +30,7 @@ describe("Sealious.CheckVersion", function() {
     });
     it("throws an error because an invalid argument was passed", function() {
         assert.throws(function() {
-            CheckVersion("troll");
+            check_for_updates("troll");
         },
         function(err) {
             if (err.type === "validation") {
@@ -40,7 +40,7 @@ describe("Sealious.CheckVersion", function() {
         "Unexpected error");
     });
     it("throws an error because a nonexisiting version was given", function(done) {
-        CheckVersion({version: "0.888888.10"})
+        check_for_updates({version: "0.888888.10"})
             .then(function() {
                 done(new Error("It didn't throw the error!"));
             })

--- a/tests/unit-tests/utils/check-version.test.js
+++ b/tests/unit-tests/utils/check-version.test.js
@@ -1,0 +1,56 @@
+const CheckVersion = require.main.require("lib/utils/check-version.js");
+const request = require("request-promise");
+const assert = require("assert");
+
+describe("Sealious.CheckVersion", function() {
+    it("says there are no updates to Sealious", function(done) {
+        request("http://registry.npmjs.org/sealious/0.7")
+            .then(res => JSON.parse(res))
+            .then(sealious_npm => CheckVersion(sealious_npm))
+            .then( ({status, message}) => {
+                assert.strictEqual(status, "info");
+                assert.notStrictEqual(message.indexOf("up-to-date"), -1);
+                done();
+            })
+            .catch(function(err) {
+                done(new Error(err));
+            });
+    });
+    it("says there are updates to Sealious", function(done) {
+        const pkg = {version: "0.7.1"};
+        CheckVersion(pkg)
+            .then( ({status, message}) => {
+                assert.strictEqual(status, "warning");
+                assert.notStrictEqual(message.indexOf("update available"), -1);
+                done();
+            })
+            .catch(function(err) {
+                done(new Error(err));
+            });
+    });
+    it("throws an error because an invalid argument was passed", function() {
+        assert.throws(function() {
+            CheckVersion("troll");
+        },
+        function(err) {
+            if (err.type === "validation") {
+                return true;
+            }
+        },
+        "Unexpected error");
+    });
+    it("throws an error because a nonexisiting version was given", function(done) {
+        CheckVersion({version: "0.888888.10"})
+            .then(function() {
+                done(new Error("It didn't throw the error!"));
+            })
+            .catch(function(err) {
+                if (err.statusCode === 404) {
+                    done();
+                }
+                else {
+                    done(new Error(err));
+                }
+            });
+    });
+});


### PR DESCRIPTION
Basically I decided to rewrite version checking to make it more testable and easier to maintain. Not everything is finished yet, I just want to share my progress. `core.js` still has the old version checking, so nothing really affects Sealious yet.

What do you think about it and what would you add to it?