### PR TITLE
Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script: npm test
 cache:
   bundler: true
   directories:
-  - node_modules # 
+  - node_modules
 install: 
 - npm install
 - npm link .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 node_js:
 - '4.4.7'
 script: npm test
+cache:
+  bundler: true
+  directories:
+  - node_modules # NPM packages
 install: 
 - npm install
 - npm link .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script: npm test
 cache:
   bundler: true
   directories:
-  - node_modules # NPM packages
+  - node_modules # 
 install: 
 - npm install
 - npm link .

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "escape-html": "^1.0.3",
     "expand-hash": "^0.2.2",
     "fs-extra": "^0.30.0",
+    "left-pad": "^1.1.1",
     "locreq": "^1.0.0",
     "merge": "^1.2.0",
     "node-uuid": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "escape-html": "^1.0.3",
     "expand-hash": "^0.2.2",
     "fs-extra": "^0.30.0",
-    "left-pad": "^1.1.1",
     "locreq": "^1.0.0",
     "merge": "^1.2.0",
     "node-uuid": "^1.4.7",


### PR DESCRIPTION
This is a set of changes meant to speed up the Travis build process. It basically tells Travis to cache the `node_modules` directory.

1. As experiments shown, it decreases `npm install` time from [around 30s](https://travis-ci.org/sealcode/sealious/builds/149126815) (see the duration next to the `npm install` command) to [around 2s](https://travis-ci.org/sealcode/sealious/builds/149135796)
2. I've checked if adding new dependencies to `package.json` causes Travis to install them as well, and [indeed it does](https://travis-ci.org/sealcode/sealious/builds/149135024)
3. The overall build process time jumped from over about a minute to around 30s.

@adwydman: Please take a look, review and merge :)