### PR TITLE
Change the decode default method to return a resolved Promise

### DIFF
--- a/lib/chip-types/field-type-default-methods.js
+++ b/lib/chip-types/field-type-default-methods.js
@@ -16,7 +16,7 @@ const default_methods = {
 		return new FieldTypeDescription(this.name);
 	},
 	decode: function(context, params, value_in_database){
-		return value_in_database;
+		return Promise.resolve(value_in_database);
 	},
 	filter_to_query: function(context, params, query){
 		return Promise.resolve(this.encode(context, params, query))

--- a/tests/unit-tests/chip-types/field-type-default-methods.test.js
+++ b/tests/unit-tests/chip-types/field-type-default-methods.test.js
@@ -2,58 +2,52 @@ const locreq = require("locreq")(__dirname);
 const assert = require("assert");
 const FieldTypeDefaultMethods = locreq("lib/chip-types/field-type-default-methods.js");
 
-describe("Sealious.FieldTypeDefaultMethods", function() {
-    it("resolves the .is_proper_value()", function(done) {
+describe("Sealious.FieldTypeDefaultMethods", function(){
+    it("resolves the .is_proper_value()", function(done){
         FieldTypeDefaultMethods.is_proper_value()
-        .then(function() {
+        .then(function(){
             done();
         }).catch(done);
     });
-    it("resolves the .format() with decoded value \"test\"", function(done) {
+    it("resolves the .format() with decoded value \"test\"", function(done){
         FieldTypeDefaultMethods.format(null, null, "test")
-        .then(function(decoded_value) {
+        .then(function(decoded_value){
             assert.strictEqual(decoded_value, "test");
             done();
         }).catch(done);
     });
-    it("resolves the .format() with decoded value null", function(done) {
+    it("resolves the .format() with decoded value null", function(done){
         FieldTypeDefaultMethods.format(null, null, null)
-        .then(function(decoded_value) {
+        .then(function(decoded_value){
             assert.strictEqual(decoded_value, null);
             done();
         }).catch(done);
     });
-    it("resolves the .encode() with value \"test\"", function(done) {
+    it("resolves the .encode() with value \"test\"", function(done){
         FieldTypeDefaultMethods.encode(null, null, "test")
-        .then(function(encoded_value) {
+        .then(function(encoded_value){
             assert.strictEqual(encoded_value, "test");
             done();
         }).catch(done);
     });
-    it("resolves the .encode() with value null", function(done) {
-        FieldTypeDefaultMethods.encode(null, null, null)
-        .then(function(encoded_value) {
-            assert.strictEqual(encoded_value, null);
+    it("returns the .decode() with value \"test\"", function(done){
+        FieldTypeDefaultMethods.decode(null, null, "test")
+        .then(function(decoded_value){
+            assert.strictEqual(decoded_value, "test");
             done();
         }).catch(done);
     });
-    it("returns the .decode() with value \"test\"", function() {
-        assert.strictEqual(FieldTypeDefaultMethods.decode(null, null, "test"), "test");
-    });
-    it("returns the .decode() with value null", function() {
-        assert.strictEqual(FieldTypeDefaultMethods.decode(null, null, null), null);
-    });
-    it("resolves the .filter_to_query() with value \"test\"", function(done) {
+    it("resolves the .filter_to_query() with value \"test\"", function(done){
         FieldTypeDefaultMethods.filter_to_query(null, null, "test")
-        .then(function(encoded) {
+        .then(function(encoded){
             assert.deepEqual(encoded, {$eq: "test"});
             done();
         }).catch(done);
     });
-    it("returns false when full_text_search_enabled called", function() {
+    it("returns false when full_text_search_enabled called", function(){
         assert.strictEqual(FieldTypeDefaultMethods.full_text_search_enabled(), false);
     });
-    it("returns the field type description", function() {
+    it("returns the field type description", function(){
         FieldTypeDefaultMethods.name = "test_name";
         const field_type = FieldTypeDefaultMethods.get_description();
         assert.strictEqual(field_type.summary, "test_name");

--- a/tests/unit-tests/chip-types/field-type.test.js
+++ b/tests/unit-tests/chip-types/field-type.test.js
@@ -69,9 +69,12 @@ describe("FieldType", function(){
 					done();
 				}).catch(done);
 			});
-			it("should use default .decode", function(){
-				const decoded = test_field_type.decode(new Context(), {}, "dogfood")
-				assert.strictEqual(decoded, "dogfood");
+			it("should use default .decode", function(done){
+				test_field_type.decode(new Context(), {}, "dogfood")
+				.then(function(decoded) {
+					assert.strictEqual(decoded, "dogfood");
+					done();
+				}).catch(done);
 			});
 			it("should use default .get_description", function(){
 				const description = test_field_type.get_description()


### PR DESCRIPTION
As @kuba-orlik and I spoke on the latest meeting, `decode` should return a resolved Promise.