### PR TITLE
Add ability to provide a http URL to a file instead of a File buffer

### DIFF
--- a/lib/base-chips/field-types/file.js
+++ b/lib/base-chips/field-types/file.js
@@ -3,6 +3,8 @@ const locreq = require("locreq")(__dirname);
 const Promise = require("bluebird");
 const File = locreq("lib/data-structures/file.js");
 const FileManager = locreq("lib/core-services/file-manager.js");
+const rp = require("request-promise");
+const url = require("url");
 
 module.exports = {
 	name: "file",
@@ -10,6 +12,14 @@ module.exports = {
 	is_proper_value: function(context, params, value){
 		if (value === undefined){
 			return undefined;
+		}
+		if (typeof value == "string"){
+			return rp({url: value, encoding: null})
+			.then(function(){
+				return Promise.resolve();
+			}).catch(function(){
+				return Promise.reject("There was a problem while getting the file: '" + value + "'. Is the URL correct?");
+			});
 		}
 		if (value === null
 			|| value === ""
@@ -28,7 +38,14 @@ module.exports = {
 		}
 	},
 	encode: function(context, params, value_in_code){
-		// it doesn't check what the value_in_code really is
+		if(typeof value_in_code === "string"){
+			return rp({url: value_in_code, encoding: null})
+			.then(function(file_buffer){
+				const filename = url.parse(value_in_code).pathname.split("/").pop();
+				const file = new File(context, filename, file_buffer);
+				return FileManager.save_file(file);
+			});
+		}
 		if (value_in_code){
 			return FileManager.save_file(value_in_code);
 		} else {

--- a/lib/data-structures/file.js
+++ b/lib/data-structures/file.js
@@ -1,14 +1,15 @@
 "use strict";
 const locreq = require("locreq")(__dirname);
+const mime = require("mime-types");
 
 const FileManager = locreq("lib/core-services/file-manager.js");
 const Promise = require("bluebird");
 
-function File (creation_context, filename, data, id, mime){
+function File (creation_context, filename, data, id, file_mime){
 	this.filename = filename;
 	this.data = data;
 	this.id = id || null;
-	this.mime = mime || false;
+	this.mime = file_mime || mime.lookup(filename);
 }
 
 File.from_id = function(context, file_id){

--- a/lib/plugins/plugin-manager.js
+++ b/lib/plugins/plugin-manager.js
@@ -43,7 +43,7 @@ function load_plugins_from_dir (dir){
 	const pkgfile = path.join(root, "package.json");
 	const pkg = require(pkgfile);
 
-	const dependencies = pkg.dependencies;
+	const dependencies = pkg.dependencies || {};
 	const required_sealious_plugins = Object.keys(dependencies).filter(is_sealious_plugin.bind({}, root));
 
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "fs-extra": "^0.30.0",
     "locreq": "^1.0.3",
     "merge": "^1.2.0",
+    "mime-types": "^2.1.11",
     "node-uuid": "^1.4.7",
     "request-promise": "^4.0.2",
     "resolve": "^1.1.7",

--- a/tests/unit-tests/base-chips/field-types/file.test.js
+++ b/tests/unit-tests/base-chips/field-types/file.test.js
@@ -19,11 +19,14 @@ describe("FieldType.File", function(){
 				filename: "test_filename",
 				data: new Buffer(1)
 			}],
+			["a proper URL to a downloadable file", "http://example.com"],
         ],
         should_reject: [
             ["a random string of text", "asofihas9efbaw837 asd"],
             ["an empty objec", {}],
 			["an object with 'filename', but without 'data'", {filename: "picture.jpg"}],
+			["a malformed http url", "htpp://example.com"],
+			["a properly formed, but non-existing http url", "http://www.da3bba42e1f6d77a63bd665d0a82ff32.org"],
         ]
     });
 


### PR DESCRIPTION
Now the `file` field-type will also accept a string containing the HTTP URL to a file. The file will be downloaded and kept on server together with other updates.