### PR TITLE
Field type html

### DIFF
--- a/lib/base-chips/_base-chips.js
+++ b/lib/base-chips/_base-chips.js
@@ -23,6 +23,7 @@ const field_types = [
 	"text",
 	"hashed-text",
 	"username",
+	"html",
 ];
 
 for(const i in access_strategy_types){

--- a/lib/base-chips/field-types/html.js
+++ b/lib/base-chips/field-types/html.js
@@ -15,7 +15,7 @@ module.exports = {
 		switch(format){
 			case "unsafe":
 				return decoded_value.original;
-			case "orginal":
+			case "original":
 				return decoded_value.original;
 			default:
 				return decoded_value.safe;

--- a/lib/base-chips/field-types/html.js
+++ b/lib/base-chips/field-types/html.js
@@ -1,0 +1,26 @@
+const sanitizeHtml = require("sanitize-html");
+
+module.exports = {
+	name: "html",
+	extends: "text",
+	encode: function(context, params, value){
+		return {
+			original: value,
+			safe: sanitizeHtml(value, {
+				allowedTags: sanitizeHtml.defaults.allowedTags.concat([ "img", "h1", "h2" ])
+			}),
+		};
+	},
+	format: function(context, decoded_value, format){
+		switch(format){
+			case "unsafe":
+				return decoded_value.original;
+			case "orginal":
+				return decoded_value.original;
+			default:
+				return decoded_value.safe;
+		}
+	}
+};
+
+

--- a/lib/utils/get-main-app-dir.js
+++ b/lib/utils/get-main-app-dir.js
@@ -1,3 +1,5 @@
+"use strict";
+
 function get_main_app_dir(){
 	let topModule = module;
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "node-uuid": "^1.4.7",
     "request-promise": "^4.0.2",
     "resolve": "^1.1.7",
+    "sanitize-html": "^1.13.0",
     "sealious-datastore-tingo": "github:sealcode/sealious-datastore-tingo#alpha",
     "shortid": "^2.2.6",
     "winston": "^1.0.0"

--- a/tests/unit-tests/base-chips/field-types/html.test.js
+++ b/tests/unit-tests/base-chips/field-types/html.test.js
@@ -1,0 +1,59 @@
+"use strict";
+const locreq = require("locreq")(__dirname);
+const Context = locreq("lib/context.js");
+const field_type_html = locreq("lib/base-chips/field-types/html.js");
+
+const test_is_proper_value = locreq("tests/util/test-is-proper-value.js");
+
+const assert = require("assert");
+const crypto = require("crypto");
+
+describe("FieldType.html", function(){
+
+	// test_is_proper_value({
+    //     field_type: field_type_html,
+    //     should_accept: [
+    //         ["a basic text string", "hello"],
+	// 		["Any html, actually: it should be pretty liberal (it's user input, after all)", "<h1>Hello!</h1>"],
+	// 		["It should accept text that is of acceptable length according to params inherited from field_type_text", "<h1>abc</h1>", {max_length: 20}],
+    //     ],
+    //     should_reject: [
+    //         ["An html string that's too long according to 'field_type_text' params", "<h1>Hello</h1>", {max_width: 1}],
+    //     ]
+    // });
+
+	describe(".encode", function(){
+		it("removes <script> tags", function(){
+			const raw_html = "<script>alert(true)</script>Hello!";
+			const encoded_value = field_type_html.encode(new Context(), {}, raw_html);
+			assert.deepEqual(encoded_value, {
+				original: raw_html,
+				safe: "Hello!",
+			});
+		});
+
+		it("removes onhover attributes", function(){
+			const raw_html = '<h1 onhover="alert(true)">Hello!</h1>';
+			const encoded_value = field_type_html.encode(new Context(), {}, raw_html);
+			assert.deepEqual(encoded_value, {
+				original: raw_html,
+				safe: "<h1>Hello!</h1>",
+			});
+		});
+
+	});
+
+	describe(".format", function(){
+		it("should return the safe version by default", function(){
+			const result = field_type_html.format(new Context(), {original: "a", safe: "b"});
+			assert.equal(result, "b");
+		});
+
+		it("should return the original version when asked for 'unsafe' format", function(){
+			const result = field_type_html.format(new Context(), {original: "a", safe: "b"}, 'unsafe');
+			assert.equal(result, "a");
+		});
+
+	});
+
+});

--- a/tests/unit-tests/base-chips/field-types/html.test.js
+++ b/tests/unit-tests/base-chips/field-types/html.test.js
@@ -54,6 +54,11 @@ describe("FieldType.html", function(){
 			assert.equal(result, "a");
 		});
 
+		it("should return the original version when asked for 'original' format", function(){
+			const result = field_type_html.format(new Context(), {original: "a", safe: "b"}, 'original');
+			assert.equal(result, "a");
+		});
+
 	});
 
 });


### PR DESCRIPTION
I've added a simple html field-type that uses the sanitize-html module to remove any possible xss vulnerabilities. It supports two formats: `safe` and `unsafe/original`
